### PR TITLE
feat: push tts-base image to hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,17 +64,17 @@ services:
     restart: unless-stopped
     networks:
       - novel-tts-network
-  tts-base:
-    build:
-      context: libs
-      dockerfile: Dockerfile
-    image: tts-base
-    container_name: tts-base-image
-    command: ["echo", "Base TTS image built successfully"]
-    environment:
-      - REDIS_URL=redis://redis:6379/0
-    networks:
-      - novel-tts-network
+  # tts-base:
+  #   build:
+  #     context: libs
+  #     dockerfile: Dockerfile
+  #   image: tts-base
+  #   container_name: tts-base-image
+  #   command: ["echo", "Base TTS image built successfully"]
+  #   environment:
+  #     - REDIS_URL=redis://redis:6379/0
+  #   networks:
+  #     - novel-tts-network
   completed-worker:
     build:
       context: workers/completed

--- a/workers/book/Dockerfile
+++ b/workers/book/Dockerfile
@@ -1,4 +1,4 @@
-FROM tts-base
+FROM kalekber/tts-base:0.0.1
 
 WORKDIR /app
 

--- a/workers/chapter/Dockerfile
+++ b/workers/chapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM tts-base
+FROM kalekber/tts-base:0.0.1
 
 WORKDIR /app
 

--- a/workers/completed/Dockerfile
+++ b/workers/completed/Dockerfile
@@ -1,4 +1,4 @@
-FROM tts-base
+FROM kalekber/tts-base:0.0.1
 
 WORKDIR /app
 

--- a/workers/converter/Dockerfile
+++ b/workers/converter/Dockerfile
@@ -1,4 +1,4 @@
-FROM tts-base
+FROM kalekber/tts-base:0.0.1
 
 WORKDIR /app
 

--- a/workers/metadata/Dockerfile
+++ b/workers/metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM tts-base
+FROM kalekber/tts-base:0.0.1
 
 WORKDIR /app
 

--- a/workers/sync/Dockerfile
+++ b/workers/sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM tts-base
+FROM kalekber/tts-base:0.0.1
 
 WORKDIR /app
 

--- a/workers/tts/Dockerfile
+++ b/workers/tts/Dockerfile
@@ -1,4 +1,4 @@
-FROM tts-base
+FROM kalekber/tts-base:0.0.1
 
 WORKDIR /app
 


### PR DESCRIPTION
TODO:
- migrate from local tts-base to dockerhub.io
- update worker Dockerfiles to new container image kalekber/tts-base:0.0.1